### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Mono compatibility
 
 Initial release with eval of selections
 
-###License
+### License
 
 Copyright (C) 2014 Enrico Sada
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
